### PR TITLE
Guard was failing because it couldn't find the fixtures.

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,7 +16,7 @@ end
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = "#{::Rails.root}/test/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
This changes the path, and should mean we can run all of the specs through guard.

