### PR TITLE
merge #160, #162 into development

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -49,7 +49,6 @@ class PeopleController < ApplicationController
   def index
     Person.per_page = params[:per_page] if params[:per_page].present? # allow for larger pages
 
-    @verified_types = Person.distinct.pluck(:verified).select(&:present?)
     # this could be cleaner...
     search = if params[:tags].blank?
                Person.active.includes(:taggings).paginate(page: params[:page]).
@@ -80,7 +79,6 @@ class PeopleController < ApplicationController
 
     @last_gift_card = Reward.last # default scope is id: :desc
     @gift_card = Reward.new
-    @verified_types = Person.distinct.pluck(:verified).select(&:present?)
     @tags = @person.tags.pluck(:name)
     # @outgoingmessages = TwilioMessage.where(to: @person.normalized_phone_number).limit(10)
     # @twilio_wufoo_formids = @outgoingmessages.distinct.pluck(:wufoo_formid)

--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -23,6 +23,7 @@ class TaggingsController < ApplicationController
   # FIXME: Refactor and re-enable cop
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   #
+  # TODO: (EL) more rigorously test tagging logic
   def create
     klass = TAGGABLE_TYPES.fetch(params[:taggable_type])
     res = false

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -59,6 +59,11 @@ class Person < ApplicationRecord
 
   acts_as_taggable
 
+  VERIFIED_TYPES = [
+    VERIFIED_TYPE = "Verified",
+    NOT_VERIFIED_TYPE = "No"
+  ]
+
   page 50
 
   # include Searchable
@@ -232,10 +237,6 @@ class Person < ApplicationRecord
       end # end cart update
       return { pid: id, old: old_level, new: new_level }
     end
-  end
-
-  def self.verified_types
-    Person.distinct.pluck(:verified).select(&:present?)
   end
 
   def signup_gc_sent

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,8 @@
 #  invitations_count       :integer          default(0)
 #
 
+# TODO: (EL) rename new_person_notification to something like is_admin
+
 class User < ApplicationRecord
   has_paper_trail ignore: [:last_sign_in_at]
   # acts_as_tagger #if we want owned tags.

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -37,8 +37,8 @@
   <div class="control-group">
     <%= f.label :verified, :class => 'control-label' %>
     <div class="controls">
-      <%= f.select :verified, 
-            options_for_select(Person.verified_types,'Verified') %> (Start with 'Verified' to save as verified)
+      <%= f.select :verified,
+            options_for_select(Person::VERIFIED_TYPES, Person::VERIFIED_TYPE) %> (Start with 'Verified' to save as verified)
     </div>
   </div>
   <div class="control-group">

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -97,7 +97,7 @@
                           :method => :delete,
                           :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
                           :class => 'btn btn-mini btn-danger btn-block' %>
-                <%= link_to 'Deactivate',
+                <%= link_to I18n.t('deactivate'),
                           deactivate_people_path(person),
                           remote: true,
                           method: :post,

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -70,7 +70,7 @@
             <td><%= address_fields_to_sentence(person) %></td>
             <td><%= best_in_place person, :email_address %></td>
             <td><%= best_in_place person, :phone_number, display_with: lambda {|p| number_to_phone(p,area_code: true) } %></td>
-            <td><%= best_in_place person, :verified, as: :select, collection: @verified_types.map{|p| [p,p]} %></td>
+            <td><%= best_in_place person, :verified, as: :select, collection: Person::VERIFIED_TYPES.map{|p| [p,p]} %></td>
             <td><%= person.low_income %></td>
             <td><%= person.created_at.to_s(:short) %></td>
             <td><%= best_in_place person, :preferred_contact_method,

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -252,7 +252,7 @@
                 data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) },
                 class: 'btn btn-danger' %>
       <% if @person.active %> <!-- active or inactive? -->
-      <%= link_to 'deactivate',
+      <%= link_to I18n.t('deactivate'),
                 deactivate_people_path(@person),
                 method: :post,
                 data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) },

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -24,7 +24,7 @@
           content: "This means that the name and contact info has been verified. We know this person is an actual person, and at one point the phone number/email address was correct.",
           title: 'popover',
           original_title:"Verification"} %></dt>
-          <dd><%= best_in_place @person, :verified, as: :select, collection: @verified_types.map{|p| [p,p]} %></dd>
+          <dd><%= best_in_place @person, :verified, as: :select, collection: Person::VERIFIED_TYPES.map{|p| [p,p]} %></dd>
 
           <dt>Low Income? <%= content_tag :span,'?',class: 'badge', data:{
           toggle: "popover", 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,4 @@
 
 en:
   hello: "Hello world"
+  deactivate: "Deactivate"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -43,5 +43,10 @@ FactoryBot.define do
     name { Faker::Name.name }
     phone_number { Faker::PhoneNumber.cell_phone }
     team
+    new_person_notification false
+
+    trait :admin do
+      new_person_notification  true
+    end
   end
 end

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -184,10 +184,4 @@ feature "people page" do
     visit people_path
     expect(page).not_to have_content(email_address)
   end
-
-  scenario 'search people by tag' do
-  end
-
-  scenario "show person's details" do
-  end
 end

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -105,6 +105,12 @@ feature "people page" do
     expect(page).to have_content("#{person.full_name} re-activated")
     expect(page).to have_content(updated_email_address)
     expect(person.reload.active).to eq(true)
+
+    # delete person
+    find(:xpath, "//a[@href='#{person_path(person.id)}' and @data-method='delete']").click
+    expect(page.current_path).to eq(people_path)
+    expect(page).not_to have_content(updated_email_address)
+    expect { person.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   scenario 'create new, unverified person' do

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -89,12 +89,22 @@ feature "people page" do
     # deactivate person
     expect(RapidproDeleteJob).to receive(:perform_async).with(person.id)
     find(:xpath, "//a[@href='#{deactivate_people_path(person.id)}']").click
-    expect(page).to have_content("#{person.first_name} #{person.last_name} deactivated")
+    expect(page).to have_content("#{person.full_name} deactivated")
     expect(page).not_to have_content(updated_email_address)
     person.reload
     expect(person.active).to eq(false)
     expect(person.deactivated_at).to be_truthy
     expect(person.deactivated_method).to eq('admin_interface')
+
+    # reactivate person
+    expect(RapidproUpdateJob).to receive(:perform_async).with(person.id)
+    visit person_path(person.id)
+    expect(page).to have_content("#{person.full_name} | Deactivated")
+    find(:xpath, "//a[@href='#{reactivate_people_path(person.id)}']").click
+    expect(page.current_path).to eq(people_path)
+    expect(page).to have_content("#{person.full_name} re-activated")
+    expect(page).to have_content(updated_email_address)
+    expect(person.reload.active).to eq(true)
   end
 
   scenario 'create new, unverified person' do

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+feature "people page" do
+  let(:first_name) { "Doggo" }
+  let(:last_name) { "Johnson" }
+  let(:phone_number) { "6665551234" }
+  let(:email_address) { "eugene@asdf.com" }
+  let(:postal_code) { "11101" }
+  let(:landline) { "6667772222" }
+  let(:participation_type) { "remote" }
+
+  scenario 'create new person' do
+    login_with_admin_user
+    visit '/people'
+
+    click_link 'New Person'
+    expect(page).to have_selector(:link_or_button, 'Create Person')
+
+    fill_in 'First name', with: first_name
+    fill_in 'Last name', with: last_name
+    fill_in 'Phone number', with: phone_number
+    fill_in 'Email address', with: email_address
+    fill_in 'Postal code', with: postal_code
+    fill_in 'Landline', with: landline
+    select participation_type, from: 'Participation type'
+    select Person::VERIFIED_TYPE, from: 'Verified'
+    click_button 'Create Person'
+    expect(page).to have_selector(:link_or_button, 'Update Person')
+
+    new_person = Person.order(:id).last
+    expect(new_person.first_name).to eq(first_name)
+    expect(new_person.last_name).to eq(last_name)
+    expect(new_person.phone_number).to eq("+1#{phone_number}")
+    expect(new_person.email_address).to eq(email_address)
+    expect(new_person.postal_code).to eq(postal_code)
+    expect(new_person.landline).to eq("+1#{landline}")
+    expect(new_person.participation_type).to eq(participation_type)
+    expect(new_person.verified).to eq(Person::VERIFIED_TYPE)
+
+    visit people_path
+    expect(page).to have_content(email_address)
+  end
+end

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -73,8 +73,13 @@ feature "people page" do
     assert_person_created(verified: Person::VERIFIED_TYPE)
     expect(page).to have_content(email_address)
 
-    # edit person's email
     person = Person.order(:id).last
+
+    # show person details page
+    click_link person.full_name
+    expect(page.current_path).to eq(person_path(person.id))
+
+    # edit person's email
     updated_email_address = "eugeneupdated@asdf.com"
     find(:xpath, "//a[@href='#{edit_person_path(person.id)}']").click
 

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -134,7 +134,14 @@ feature "people page" do
   scenario 'create new, unverified person' do
     add_new_person(verified: Person::NOT_VERIFIED_TYPE)
     assert_person_created(verified: Person::NOT_VERIFIED_TYPE)
-    # unverified people don't show up in list
+
+    # admin users can see unverified people
+    visit people_path
+    expect(page).to have_content(email_address)
+
+    # non-admin users can't see unverified people
+    admin_user.update(new_person_notification: false)
+    visit people_path
     expect(page).not_to have_content(email_address)
   end
 

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -86,6 +86,24 @@ feature "people page" do
     visit people_path
     expect(page).to have_content(updated_email_address)
 
+    # non-admin can't reactivate/delete person
+    admin_user.update(new_person_notification: false)
+    visit people_path
+    expect(page).not_to have_content(I18n.t('deactivate'))
+    expect(page).not_to have_content("Delete")
+    visit person_path(person.id)
+    expect(page).not_to have_content(I18n.t('deactivate'))
+    expect(page).not_to have_content("Delete")
+
+    # admin can reactivate/delete person
+    admin_user.update(new_person_notification: true)
+    visit people_path
+    expect(page).to have_content(I18n.t('deactivate'))
+    expect(page).to have_content("Delete")
+    visit person_path(person.id)
+    expect(page).to have_content(I18n.t('deactivate'))
+    expect(page).to have_content("Delete")
+
     # deactivate person
     expect(RapidproDeleteJob).to receive(:perform_async).with(person.id)
     find(:xpath, "//a[@href='#{deactivate_people_path(person.id)}']").click
@@ -120,15 +138,9 @@ feature "people page" do
     expect(page).not_to have_content(email_address)
   end
 
-  scenario 'delete person' do
-  end
-
-  scenario 'deactivate person' do
-  end
-
-  scenario 'edit person' do
-  end
-
   scenario 'search people by tag' do
+  end
+
+  scenario "show person's details" do
   end
 end

--- a/spec/features/people_spec.rb
+++ b/spec/features/people_spec.rb
@@ -12,6 +12,7 @@ feature "people page" do
   let(:participation_type) { "remote" }
   let(:preferred_contact_method) { { value: "SMS", label: "Text Message" } }
   let(:low_income) { true }
+  let(:last_person) { }
 
   let(:now) { DateTime.current }
 
@@ -67,10 +68,23 @@ feature "people page" do
     expect(new_person.low_income).to eq(low_income)
   end
 
-  scenario 'create new, verified person' do
+  scenario 'create new, verified person, and edit their information' do
     add_new_person(verified: Person::VERIFIED_TYPE)
     assert_person_created(verified: Person::VERIFIED_TYPE)
     expect(page).to have_content(email_address)
+
+    # edit person's email
+    person = Person.order(:id).last
+    updated_email = "eugeneupdated@asdf.com"
+    find(:xpath, "//a[@href='#{edit_person_path(person.id)}']").click
+
+    fill_in 'Email address', with: updated_email
+    click_button 'Update Person'
+    expect(page).to have_content('Person was successfully updated.')
+    expect(page.current_path).to eq(person_path(person.id))
+    expect(person.reload.email_address).to eq(updated_email)
+
+    visit people_path
   end
 
   scenario 'create new, unverified person' do
@@ -78,5 +92,17 @@ feature "people page" do
     assert_person_created(verified: Person::NOT_VERIFIED_TYPE)
     # unverified people don't show up in list
     expect(page).not_to have_content(email_address)
+  end
+
+  scenario 'delete person' do
+  end
+
+  scenario 'deactivate person' do
+  end
+
+  scenario 'edit person' do
+  end
+
+  scenario 'search people by tag' do
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,6 +1,5 @@
 module Helpers
-  def login_with_admin_user
-    user = FactoryBot.create(:user)
+  def login_with_admin_user(user = FactoryBot.create(:user))
     visit '/users/sign_in'
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password


### PR DESCRIPTION
- Feature/people page specs pt1 #160 
- Feature/people pages spec pt2 #162

together, these PRs test some basic functionality around person records, including
- adding a person (verified/unverified)
- deactivating/reactivating a person
- deleting a person
- admin/non-admin user permissions around person activation/deletion
- adding/deleting tags on a person


